### PR TITLE
[Config] Enable dynamic groovy scripting

### DIFF
--- a/elasticsearch/templates/elasticsearch.yml.jinja
+++ b/elasticsearch/templates/elasticsearch.yml.jinja
@@ -362,3 +362,7 @@ network.host: {{ network.host }}
 # it unless you need it is recommended (it is disabled by default).
 #
 #http.jsonp.enable: true
+
+################################## Scripting ################################
+
+script.groovy.sandbox.enabled: {{ script_groovy_sandbox_enabled|default('false') }}

--- a/pillar.example
+++ b/pillar.example
@@ -4,3 +4,7 @@ elasticsearch:
 
   # The version for the apt repository.
   repo_version: 1.4
+
+  config:
+    # Enable dynamic scripting
+    script_groovy_sandbox_enabled: true


### PR DESCRIPTION
This PR introduces the option to set the `script.groovy.sandbox.enabled` flag to true, which is not the default.
