### PR TITLE
Adds option to enable inline scripts

### DIFF
--- a/elasticsearch/templates/elasticsearch.yml.jinja
+++ b/elasticsearch/templates/elasticsearch.yml.jinja
@@ -383,3 +383,5 @@ cloud.aws:
 ################################## Scripting ################################
 
 script.groovy.sandbox.enabled: {{ script_groovy_sandbox_enabled|default('false') }}
+script.inline: {{ script_inline|default('off') }}
+script.indexed: {{ script_indexed|default('off') }}

--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,8 @@ elasticsearch:
   config:
     # Enable dynamic scripting
     script_groovy_sandbox_enabled: true
+    script_inline: on
+    script_indexed: on
 
   plugins:
     analysis-icu:


### PR DESCRIPTION
Enabling inline scripts changed in Elasticsearch > 2.0, see https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_setting_changes.html#migration-script-settings.

To enable scripts it is now needed to set:

```
script.inline: on
script.indexed: on
```

This PR allows to set two new config options in the pillars files.

```
script_inline: on
script_indexed: on
```
