### PR TITLE
Fix curator command for recent versions

### DIFF
--- a/elasticsearch/curator.sls
+++ b/elasticsearch/curator.sls
@@ -14,7 +14,7 @@ elasticsearch-curator:
 {%- set time_unit = data.get('curator-time-unit', 'days') %}
 {%- set timestring = data.get('curator-timestring', '%Y.%m.%d') %}
 
-/usr/local/bin/curator delete indices --prefix "{{ index }}-" --older-than {{ older_than }} --time-unit {{ time_unit }} --timestring {{ timestring }}:
+/usr/local/bin/curator delete indices --prefix "{{ index }}-" --older-than {{ older_than }} --time-unit {{ time_unit }} --timestring {{ timestring|replace('%', '\%') }}:
   cron.present:
     - identifier: Auto-cleaning old ES data for {{ index }}
     - user: root

--- a/elasticsearch/curator.sls
+++ b/elasticsearch/curator.sls
@@ -12,8 +12,9 @@ elasticsearch-curator:
 {%- for index, data in indices.items() %}
 {%- set older_than = data.get('curator-older-than', '30') %}
 {%- set time_unit = data.get('curator-time-unit', 'days') %}
+{%- set timestring = data.get('curator-timestring', '%Y.%m.%d') %}
 
-/usr/local/bin/curator delete --prefix "{{ index }}-" --older-than {{ older_than }} --time-unit {{ time_unit }}:
+/usr/local/bin/curator delete indices --prefix "{{ index }}-" --older-than {{ older_than }} --time-unit {{ time_unit }} --timestring {{ timestring }}:
   cron.present:
     - identifier: Auto-cleaning old ES data for {{ index }}
     - user: root


### PR DESCRIPTION
The curator command used here is incompatible with the latest version of curator (3.5.0). It now requires:
- a [subcommand](https://www.elastic.co/guide/en/elasticsearch/client/curator/3.5/delete.html) for selection of indices or snapshots
- a [`timestring`](https://www.elastic.co/guide/en/elasticsearch/client/curator/3.5/timestring.html) option

The only place currently I see curator being used is [here](https://github.com/Enrise/Saltmaster/blame/74bcf5741822c6dc9a972db2bcc88cf911e0dfff/salt/environments/prod/pillars/nodes/logging01.sls#L9-L15). Those lines should not be working correctly with any recent version of curator.
@eXistenZNL since you originally authored those lines, can you verify?
