### PR TITLE
make compression configurable

### DIFF
--- a/elasticsearch/templates/elasticsearch.yml.jinja
+++ b/elasticsearch/templates/elasticsearch.yml.jinja
@@ -192,7 +192,7 @@ network.host: {{ network.host }}
 
 # Enable compression for all communication between nodes (disabled by default):
 #
-#transport.tcp.compress: true
+transport.tcp.compress: {{ transport.tcp.compress|default('false') }}
 
 # Set a custom port to listen for HTTP traffic:
 #


### PR DESCRIPTION
### Context
In https://github.com/Enrise/Saltmaster/pull/1562 I wanted to introduce compression, but this never worked as the configuration works different from what I expected

### What has been done
- added tcp compress option with same default as elasticsearch

### Todo
- [x] approval from @edwardsmit 