### PR TITLE
Add memory_lock next to mlockall

### DIFF
--- a/elasticsearch/templates/elasticsearch.yml.jinja
+++ b/elasticsearch/templates/elasticsearch.yml.jinja
@@ -153,6 +153,9 @@ plugin.mandatory: {{ plugin.mandatory|join(',') }}
 {%- if 'mlockall' in bootstrap: %}
 bootstrap.mlockall: {{ bootstrap.mlockall }}
 {%- endif %}
+{%- if 'memory_lock' in bootstrap: %}
+bootstrap.memory_lock: {{ bootstrap.memory_lock }}
+{%- endif %}
 
 # Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
 # to the same value, and that the machine has enough memory to allocate


### PR DESCRIPTION
ES5 seems to require `memory_lock: True` instead of `mlockall: True`. This PR adds this option, but leaves in the old `mlockall` option for versions below ES5.